### PR TITLE
Document future DB-backend path + annotate archive table script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ You should now see the webpage populated with the data from the spreadsheet.
 Important: For the webpage to display correctly, you must download the "web" folder and rename it to "openhouse". This ensures that all the links to CSS and other assets are correct.
 
 Please note that this is a work in progress, and aspects of the project may change.
+
+Future Works:
+
+Right now, we are using the HTML in the web/7research file titled templateREAL.html. While this way of doing things is good, it is not ideal. Ideally, having a database backend would be great. Some of the implementation for this could be found in the other template files in the web/7research folder. We would want a backend database as this would both make load times faster as well as make future debugging easier. This is something to look into in the future. The code that I had working with the python files importSheet.py and app.py is made for SQLite and would download the CSV, turn it into a DB, and then turn the DB into a JSON file to be used by the JavaScript. Ideally, if we could get rid of JavaScript from the webpage, that would be great, as some people might not have enabled JavaScript, so the webpage might not function for them without it. Fixing this issue would help with accessibility on the webpage.

--- a/web/7research/templateREAL.html
+++ b/web/7research/templateREAL.html
@@ -47,22 +47,26 @@
 <table id="data-table" class="display" style="width:100%">
         <thead></thead>
         <tbody></tbody>
-    </table>
+    </table> 
+	 <!-- imports needed to get the CSV into JSON and to display the table -->
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
 
     <script>
+		//place to put the URL for the googlesheet which is then turned into a CSV
         const GOOGLE_SHEET_URL = 'https://docs.google.com/spreadsheets/d/1dNfbGlGUQyahnOnTGAttpAUslrAX1JT_BJZCRbYG-nQ/gviz/tq?tqx=out:csv';
 
         fetch(GOOGLE_SHEET_URL)
           .then(res => {
+			  //checks if we get a response from the google sheet
             if (!res.ok) {
               throw new Error(`Network Error. Status: ${res.status}`);
             }
             return res.text();
           })
           .then(csvText => {
+			  //paperparse library used to turn the CSV into a javascript object we can modtify
             Papa.parse(csvText, {
               header: true,
               complete: function(results) {
@@ -73,10 +77,11 @@
                 }
                 
                 const allColumnHeaders = Object.keys(data[0]);
-
+				//only displays the rob that are "ready" according to the google spreadsheet
                 const readyColumnName = allColumnHeaders.find(h => h.toLowerCase().includes('ready') && h.toLowerCase().includes('website'));
                 const filePathColumnName = allColumnHeaders.find(h => h.toLowerCase().includes('path'));
-                
+
+				  //only shows the columns that have the keyword display in the googlesheet
                 let headersToShow = allColumnHeaders.filter(header => header.toLowerCase().includes('display'));
 
                 if (headersToShow.length === 0) {
@@ -84,7 +89,7 @@
                     headersToShow = allColumnHeaders.filter(h => h && !specialColumns.includes(h));
                 }
 
-
+				//creates the table
                 const table = document.getElementById('data-table');
                 const thead = table.querySelector('thead');
                 const tbody = table.querySelector('tbody');
@@ -101,6 +106,7 @@
 
                 headersToShow.forEach(headerKey => {
                   const th = document.createElement('th');
+					//cleans the column names to be ready for display
                   const cleanTitle = headerKey
                     .replace(/\[.*?\]/g, '')
                     .replace(/_?display/ig, '')


### PR DESCRIPTION
Adds a "Future Works" section to the README outlining a database-backed, JavaScript-free rebuild (for faster loads and better accessibility) and pointing at the existing `importSheet.py`/`app.py` SQLite path. Also adds inline comments to the archive table script explaining the CSV fetch, PapaParse conversion, and the ready/display column filtering.